### PR TITLE
Fix BGR color extraction

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -237,9 +237,9 @@ void palset(int position, int bgr555) {
     if (position < 0 || position >= PALETTE_SIZE) return;
 
     // Extract BGR555 components (5 bits each)
-    int r5 = (bgr555 >> 0) & 0x1F;
+    int b5 = (bgr555 >> 0) & 0x1F;
     int g5 = (bgr555 >> 5) & 0x1F;
-    int b5 = (bgr555 >> 10) & 0x1F;
+    int r5 = (bgr555 >> 10) & 0x1F;
 
     // Scale from 5-bit (0-31) to 8-bit (0-255)
     palette[position].r = (r5 << 3) | (r5 >> 2);


### PR DESCRIPTION
Eu notei que as cores dos códigos hexadecimais que eu utilizava com o conversor de cores do [site do Lupi](https://lupi.api.br/docs/index.html) não eram as mesmas de quando eu utilizava no jogo.

A documentação diz que o Lupi utiliza RGB555 porém no código a extração da cor é feita utilizando um int BGR555 que estava extraindo o canal "red" primeiro que seria do canal "blue" e o canal "blue" como "red".

Antes | Depois
--- | ---
<img width="705" height="389" alt="antes" src="https://github.com/user-attachments/assets/9ad937ed-24b3-4293-bd2d-dd38c0cfee91" /> | <img width="708" height="391" alt="depois" src="https://github.com/user-attachments/assets/4d7cc511-be54-49dd-9fd3-8aa8d21d8302" />
