### PR TITLE
Button mapping and constant names

### DIFF
--- a/src/lua_api.c
+++ b/src/lua_api.c
@@ -797,22 +797,22 @@ void lua_api_init(void) {
     lua_setglobal(globalLuaState, "DOWN");
 
     lua_pushinteger(globalLuaState, GAMEPAD_BUTTON_RIGHT_FACE_RIGHT);
-    lua_setglobal(globalLuaState, "BTN_Z");
+    lua_setglobal(globalLuaState, "BTN_A");
 
     lua_pushinteger(globalLuaState, GAMEPAD_BUTTON_RIGHT_FACE_LEFT);
-    lua_setglobal(globalLuaState, "BTN_E");
+    lua_setglobal(globalLuaState, "BTN_Y");
 
     lua_pushinteger(globalLuaState, GAMEPAD_BUTTON_RIGHT_FACE_UP);
-    lua_setglobal(globalLuaState, "BTN_Q");
+    lua_setglobal(globalLuaState, "BTN_X");
 
     lua_pushinteger(globalLuaState, GAMEPAD_BUTTON_RIGHT_FACE_DOWN);
-    lua_setglobal(globalLuaState, "BTN_Z");
+    lua_setglobal(globalLuaState, "BTN_B");
 
     lua_pushinteger(globalLuaState, GAMEPAD_BUTTON_LEFT_TRIGGER_1);
-    lua_setglobal(globalLuaState, "BTN_F");
+    lua_setglobal(globalLuaState, "TRG_LEFT");
 
     lua_pushinteger(globalLuaState, GAMEPAD_BUTTON_RIGHT_TRIGGER_1);
-    lua_setglobal(globalLuaState, "BTN_G");
+    lua_setglobal(globalLuaState, "TRG_RIGHT");
 }
 
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
# Problemas
A documentação do Lupi cita SNES como referência para as constantes dos botões, porém existem alguns problemas.

## Problema 1

Certas constantes na documentação estão referenciadas com 2 botões do SNES. Exemplo:  

Constante | Valor | Descrição | Comentário
--- | --- | --- | ---
BTN_Z | 4 | Botão Z (geralmente B/Y no SNES) | Não dá pra saber se é o B ou Y
BTN_X | 5 | Botão X (geralmente A/X no SNES) | Não dá pra saber se é o A ou X

## Problema 2

No código, certos botões estão mapeados para 2 botões diferentes:

```c
lua_pushinteger(globalLuaState, GAMEPAD_BUTTON_RIGHT_FACE_RIGHT);
lua_setglobal(globalLuaState, "BTN_Z");
//...
lua_pushinteger(globalLuaState, GAMEPAD_BUTTON_RIGHT_FACE_DOWN);
lua_setglobal(globalLuaState, "BTN_Z");
```

## Problema 3

Botões mapeados no código não condizem com a documentação. Exemplo:

Na documentação:
Constante | Valor | Descrição
--- | --- | ---
BTN_G | 13 | Botão G (A no SNES)

No código:
```c
lua_pushinteger(globalLuaState, GAMEPAD_BUTTON_RIGHT_TRIGGER_1);
lua_setglobal(globalLuaState, "BTN_G");
```

Botão A no SNES seria o `GAMEPAD_BUTTON_RIGHT_FACE_RIGHT`  não `GAMEPAD_BUTTON_RIGHT_TRIGGER_1`.

## Problema 4

O botão `BTN_X` está descrito na documentação porém ausente no código.

Constante | Valor | Descrição
--- | --- | ---
BTN_X | 5 | Botão X (geralmente A/X no SNES)

# Proposta 1

> [!NOTE]
> Implementada nessa PR. 

Para corrigir os problemas citados e evitar ter que fazer o mapeamento mental da documentação (que eu imagino estar utilizando botões do teclado) e do controle do SNES eu sugiro utilizar o nome das constantes com os botões do SNES como padrão.

Eu também alterei os nomes das constants dos botões de trigger para utilizar: `TRG_LEFT`, `TRG_RIGHT`.

# Proposta 2

Eu entendo também que não queremos ficar vinculados a nenhum controle específico. Com isso em mente uma segunda proposta seria dar nomes mais genéricos para esses botões eu pensei em dois mapeamentos:

## Mapeamento 1

Chamar os botões pela posição:

Nome da constante | Equivalente no SNES
--- | ---
BTN_UP | X
BTN_LEFT | Y
BTN_RIGHT | A
BTN_DOWN | B
TRG_LEFT | Trigger left
TRG_RIGHT | Trigger right

A vantagem é que estamos usando a posição dos botões, mas a desvantagem é que pode confudir com os já existentes UP, LEFT, RIGHT e DOWN dos direcionais.

## Mapeamento 2

Se queremos um mapeamento próprio eu sugiro ir com ABCD mesmo.

Nome da constante | Equivalente no SNES
--- | ---
BTN_A | X
BTN_B | Y
BTN_C | A
BTN_D | B
TRG_LEFT | Trigger left
TRG_RIGHT | Trigger right

A vantagem é que utilizamos um mapeamento próprio e com um aspecto educativo, com a desvantagem que será específico do Lupi.